### PR TITLE
docs(README): correct reference to `Hubspot odometer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 angular-odometer
 ==============
 
-Angular.JS directive for [Hubspot angular-odometer](http://github.hubspot.com/odometer/docs/welcome/).
+Angular.JS directive for [Hubspot odometer](http://github.hubspot.com/odometer/docs/welcome/).
 
 Copyright (C) 2014, Sebastian Wallin <sebastian.wallin@gmail.com>
 


### PR DESCRIPTION
This project is `angular-odometer` providing directives wrapping `Hubspot odometer` functionality. This change corrects the reference to `Hubspot odometer` in the `README.md` file.
